### PR TITLE
Bump pymongo[srv] from 4.6.3 to 4.7.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ ffmpeg-python==0.2.0
 redis==5.0.2
 telegraph==2.2.0
 motor
-pymongo[srv]==4.6.3
+pymongo[srv]==4.7.2
 odmantic==0.9.2
 opencv-python-headless==4.9.0.80
 pykeyboard==0.1.5


### PR DESCRIPTION
Bumps [pymongo[srv]](https://github.com/mongodb/mongo-python-driver) from 4.6.3 to 4.7.2.
- [Release notes](https://github.com/mongodb/mongo-python-driver/releases)
- [Changelog](https://github.com/mongodb/mongo-python-driver/blob/4.7.2/doc/changelog.rst)
- [Commits](https://github.com/mongodb/mongo-python-driver/compare/4.6.3...4.7.2)

---
updated-dependencies:
- dependency-name: pymongo[srv] dependency-type: direct:production update-type: version-update:semver-minor ...